### PR TITLE
Fixed build error on VS2013

### DIFF
--- a/src/lib/cleaver/Vertex.h
+++ b/src/lib/cleaver/Vertex.h
@@ -43,13 +43,14 @@
 
 #include <vector>
 #include <cstring>
+#include <stdint.h>
 #include "vec3.h"
 #include "Geometry.h"
 
 namespace cleaver
 {
 
-enum class Order : std::int8_t {
+enum class Order : int8_t {
     VERT = 0,
     CUT  = 1,
     TRIP = 2,


### PR DESCRIPTION
Problem: build error on Visual Studio 2013

    2>c:\d\slicersegmentmesher-win64rel\cleaver\src\lib\cleaver\Vertex.h(53): error C2039: 'int8_t' : is not a member of 'std'

Solution: int8_t is used instead of std::int8_t (and stdint.h is included). This is how it is done in all other places in Cleaver2, and it works well in Visual Studio 2013.

See for example:

https://github.com/SCIInstitute/Cleaver2/blob/6f4a945867b0ccad44102ba00d2d25cdd3157ede/src/lib/cleaver/TetMesh.cpp#L55

https://github.com/SCIInstitute/Cleaver2/blob/master/src/lib/cleaver/TetMesh.cpp#L1590
