### PR TITLE
Use logical AND operator in OctreeMesher

### DIFF
--- a/src/lib/cleaver/OctreeMesher.cpp
+++ b/src/lib/cleaver/OctreeMesher.cpp
@@ -321,7 +321,7 @@ void OctreeMesherImp::adaptCell(OTCell *cell)
 
   // if cell completely inside, done
  else if(cell->bounds.maxCorner().x <= max_x &&
-         cell->bounds.maxCorner().y <= max_y &
+         cell->bounds.maxCorner().y <= max_y &&
          cell->bounds.maxCorner().z <= max_z)
  {
    cell->celltype = OTCell::Inside;


### PR DESCRIPTION
Identified in ITKCleaver CI:

  _deps\cleaver_lib-src\src\lib\cleaver\OctreeMesher.cpp(325): warning C4554: '&': check operator precedence for possible error; use parentheses to clarify precedence
