### PR TITLE
Address SizingFieldCreator possible loss of data warnings

### DIFF
--- a/src/lib/cleaver/SizingFieldCreator.cpp
+++ b/src/lib/cleaver/SizingFieldCreator.cpp
@@ -791,7 +791,7 @@ namespace cleaver
 
   void exponentiate(VoxelMesh &mesh)
   {
-    int a, b, c, i, j, k;
+    size_t a, b, c, i, j, k;
     a = mesh.distSizeX();
     b = mesh.distSizeY();
     c = mesh.distSizeZ();


### PR DESCRIPTION
For:

  _deps\cleaver_lib-src\src\lib\cleaver\SizingFieldCreator.cpp(795):
  warning C4267: '=': conversion from 'size_t' to 'int', possible loss
  of data

  _deps\cleaver_lib-src\src\lib\cleaver\SizingFieldCreator.cpp(796):
  warning C4267: '=': conversion from 'size_t' to 'int', possible loss of
  data

  _deps\cleaver_lib-src\src\lib\cleaver\SizingFieldCreator.cpp(797):
  warning C4267: '=': conversion from 'size_t' to 'int', possible loss of
  data