### PR TITLE
Check directly for negative sqrt and divide by zero in SizingField

### DIFF
--- a/src/lib/cleaver/SizingFieldCreator.cpp
+++ b/src/lib/cleaver/SizingFieldCreator.cpp
@@ -715,8 +715,8 @@ namespace cleaver
           }
         }
 
-        x = (-coeff[1] + sqrt((coeff[1] * coeff[1]) - 4 * coeff[0] * coeff[2])) / (2 * coeff[0]);
-        if (isnan(x))
+        // check for coeff that could cause NaN when calculating x below
+        if (((coeff[1] * coeff[1]) - 4 * coeff[0] * coeff[2]) < 0 || coeff[0] == 0.0)
         {
           coeff[0] = 0;
           coeff[1] = 0;
@@ -761,8 +761,8 @@ namespace cleaver
             coeff[1] -= 2 * val1;
             coeff[2] += val1*val1;
           }
-          x = (-coeff[1] + sqrt((coeff[1] * coeff[1]) - 4 * coeff[0] * coeff[2])) / (2 * coeff[0]);
         }
+        x = (-coeff[1] + sqrt((coeff[1] * coeff[1]) - 4 * coeff[0] * coeff[2])) / (2 * coeff[0]);
 
         //push into queue
         newtemp.dist = x;


### PR DESCRIPTION
Instead of relying on isNan(), check directly for conditions that could
cause NaN. On Windows by default, a negative sqrt() will throw a
floating point exception, halting the program. Changing this code is
more convenient for consumers of the cleaver library.

I encounter this issue while developing the [VTK filter wrapper](https://github.com/SCIInstitute/VTKCleaver/pull/1) for Cleaver2.