### PR TITLE
COMP: Fix build updating directory case in library header copy & install rules

### DIFF
--- a/src/lib/cleaver/CMakeLists.txt
+++ b/src/lib/cleaver/CMakeLists.txt
@@ -90,10 +90,10 @@ if(COPY_HEADER_FILES) #TODO: Needs to be added to installation step for using as
     # When debugging, uncomment this line
     get_filename_component(file_no_path "${header_file}" NAME)
     configure_file("${header_file}"
-      "${CMAKE_BINARY_DIR}/include/Cleaver/${file_no_path}" COPYONLY IMMEDIATE)
+      "${CMAKE_BINARY_DIR}/include/cleaver/${file_no_path}" COPYONLY IMMEDIATE)
     set(Cleaver_INSTALLED_HEADER_FILES
       ${Cleaver_INSTALLED_HEADER_FILES}
-      "${CMAKE_BINARY_DIR}/include/Cleaver/${file_no_path}")
+      "${CMAKE_BINARY_DIR}/include/cleaver/${file_no_path}")
   endforeach()
 endif()
 


### PR DESCRIPTION
This commit fixes the build of the Cleaver gui application, Cleaver
examples and client project against Cleaver library on case
sensitive file-system.

It ensures preprocessor directives like `#include <cleaver/Cleaver.h>`
are valid by updating the copy & install rules to use in "cleaver"
sub-directory instead of "Cleaver".