### PR TITLE
COMP: Clean up TetMesh halfEdges

### DIFF
--- a/src/lib/cleaver/TetMesh.cpp
+++ b/src/lib/cleaver/TetMesh.cpp
@@ -103,6 +103,12 @@ namespace cleaver
   }
 
   TetMesh::~TetMesh() {
+    // Delete of half edges in map of vert pairs
+    for (auto & x : halfEdges)
+    {
+      x.second->halfFaces.clear();
+      delete x.second;
+    }
 
     // delete tets verts, faces, etc
     for (size_t f = 0; f < faces.size(); f++) {


### PR DESCRIPTION
Addresses memory leak and crash in itk-wasm/ITKCleaver WASI build:

```
Error: failed to run main module `./wasi-build/itk-cleaver.wasi.wasm`

Caused by:
    0: failed to invoke command default
    1: error while executing at wasm backtrace:
           0: 0x2237dc - <unknown>!__cxx_global_array_dtor.1998
           1: 0xb09e1 - <unknown>!__funcs_on_exit
           2: 0xb095f - <unknown>!__wasm_call_dtors
           3: 0x327f1f - itk_wasm_delayed_exit
                           at /ITKWebAssemblyInterface/src/initialization.cxx:36:3
           4: 0x327fa8 - _start
                           at /ITKWebAssemblyInterface/src/initialization.cxx:63:3
    2: wasm trap: undefined element: out of bounds table access
```