### PR TITLE
COMP: Modernize CMake for add_subdirectory, googletest, and CMake 4.0 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ docs/_build
 .svn
 msvc
 src/test/test_data/input/mickey_material_fields
+.cache

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "cmake.sourceDirectory": "/home/l5cui/projects/Cleaver/src",
+    "clangd.arguments": [
+        "-background-index",
+        "-compile-commands-dir=${workspaceFolder}/build",
+        "-j=4",
+        "-log=verbose",
+        "-clang-tidy",
+        "--enable-config",
+    ],
+}

--- a/docs/build.md
+++ b/docs/build.md
@@ -32,10 +32,10 @@ Users of the Cleaver command line tool or graphical interface may not need to bu
 
 The table below describes some of build options available when configuring Cleaver using CMake.
 
-| Option      | Description | Default |
-|-------------|-------------|---------|
-| `BUILD_CLI` | Build Cleaver Command Line Tool (CLI) application   | `OFF` |
-| `BUILD_GUI` | Build Cleaver Graphical Interface (GUI) application | `OFF` |
+| Option      | Description                                         | Default |
+| ----------- | --------------------------------------------------- | ------- |
+| `BUILD_CLI` | Build Cleaver Command Line Tool (CLI) application   | `OFF`   |
+| `BUILD_GUI` | Build Cleaver Graphical Interface (GUI) application | `OFF`   |
 
 :::{tip}
 By default, when both `BUILD_CLI` and `BUILD_GUI` are `OFF`, only the <project:manual.md#cleaver-library> is built.
@@ -51,10 +51,10 @@ By default, when both `BUILD_CLI` and `BUILD_GUI` are `OFF`, only the <project:m
 
 ### Libraries
 
-|       | Command Line Tool                 | Graphical Interface               |
-|-------|-----------------------------------|-----------------------------------|
-| ITK   | {octicon}`check;1em;sd-text-info` | {octicon}`check;1em;sd-text-info` |
-| Qt    |                                   | {octicon}`check;1em;sd-text-info` |
+|     | Command Line Tool                 | Graphical Interface               |
+| --- | --------------------------------- | --------------------------------- |
+| ITK | {octicon}`check;1em;sd-text-info` | {octicon}`check;1em;sd-text-info` |
+| Qt  |                                   | {octicon}`check;1em;sd-text-info` |
 
 
 **Qt**:
@@ -81,15 +81,14 @@ Once CMake, Qt, ITK have been installed and/or built:
 git clone https://github.com/SCIInstitute/Cleaver.git $HOME/Cleaver
 
 cmake \
-  -DITK_DIR:PATH=$HOME/ITK-build \
-  -DQt5_DIR:PATH=/Path/To/Qt5/lib/cmake/Qt5 \
+  -DITK_DIR:PATH=~/projects/ITK-build \
   -DCMAKE_BUILD_TYPE:STRING=Release \
   -DBUILD_CLI:BOOL=ON \
   -DBUILD_GUI:BOOL=ON \
-  -S $HOME/Cleaver/src \
-  -B $HOME/Cleaver-build
+  -S ~/projects/Cleaver/src \
+  -B build
 
-cmake --build $HOME/Cleaver-build --config Release --parallel 8
+cmake --build build --config Release --parallel 8
 ```
 
 ### Windows

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,7 +43,7 @@ cmake_minimum_required(VERSION 3.10.2)
 set(_msg "Setting C++ standard")
 message(STATUS "${_msg}")
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -51,6 +51,7 @@ message(STATUS "${_msg} - C++${CMAKE_CXX_STANDARD}")
 
 project(CLEAVER2)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # Update CMake module path
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 
@@ -58,8 +59,8 @@ include(cleaverInitializeBuildType)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin CACHE INTERNAL
-    "Single output directory for building all executables.")
+# set(EXECUTABLE_OUTPUT_PATH ${CLEAVER2_BINARY_DIR}/bin CACHE INTERNAL
+#     "Single output directory for building all executables.")
 
 mark_as_advanced( CLEAVER2_RUNTIME_DIR CLEAVER2_BUNDLE_DIR)
 set(CLEAVER2_RUNTIME_DIR "bin" CACHE STRING
@@ -73,16 +74,17 @@ endif()
 
 # Build Cleaver Library
 include_directories(lib/cli11)
+# include_directories((/usr/include/c++/11))
 add_subdirectory(lib/jsoncpp)
 add_subdirectory(lib/cleaver)
 
 # TODO(jonbronson): Change to not use ITK by default once teem is added.
-option(USE_ITK "Use ITK instead of Teem for nrrd files." ON)
+option(USE_ITK "Use ITK instead of Teem for nrrd files." OFF)
 if(NOT USE_ITK)
   add_subdirectory(lib/teem)
 endif()
 
-option(BUILD_CLI "Build Cleaver CLI App (REQUIRES TEEM)" OFF)
+option(BUILD_CLI "Build Cleaver CLI App (REQUIRES TEEM)" ON)
 option(BUILD_GUI "Build Cleaver GUI App (REQUIRES TEEM)" OFF)
 
 option(BUILD_EXTRAS "Example use cases, tools" OFF)

--- a/src/CodeCoverage.cmake
+++ b/src/CodeCoverage.cmake
@@ -42,7 +42,7 @@
 find_program( GCOV_PATH gcov )
 find_program( LCOV_PATH lcov )
 find_program( GENHTML_PATH genhtml )
-find_program( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/tests)
+find_program( GCOVR_PATH gcovr PATHS ${CLEAVER2_SOURCE_DIR}/tests)
 
 if(NOT GCOV_PATH)
   message(FATAL_ERROR "gcov not found! Aborting...")
@@ -117,7 +117,7 @@ function(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
     COMMAND ${GENHTML_PATH} -o ${_outputname} ${_outputname}.info.cleaned
     COMMAND ${CMAKE_COMMAND} -E remove ${_outputname}.info ${_outputname}.info.cleaned
 
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    WORKING_DIRECTORY ${CLEAVER2_BINARY_DIR}
     COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
     )
 
@@ -150,8 +150,8 @@ function(SETUP_TARGET_FOR_COVERAGE_COBERTURA _targetname _testrunner _outputname
     ${_testrunner} ${ARGV3}
 
     # Running gcovr
-    COMMAND ${GCOVR_PATH} -x -r ${CMAKE_SOURCE_DIR} -e '${CMAKE_SOURCE_DIR}/tests/'  -o ${_outputname}.xml
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMAND ${GCOVR_PATH} -x -r ${CLEAVER2_SOURCE_DIR} -e '${CLEAVER2_SOURCE_DIR}/tests/'  -o ${_outputname}.xml
+    WORKING_DIRECTORY ${CLEAVER2_BINARY_DIR}
     COMMENT "Running gcovr to produce Cobertura code coverage report."
     )
 

--- a/src/lib/cleaver/CMakeLists.txt
+++ b/src/lib/cleaver/CMakeLists.txt
@@ -79,7 +79,7 @@ set(Cleaver_API_HEADER_FILES
 add_definitions(-DTETLIBRARY)
 
 # Add library includes
-include_directories(${CMAKE_BINARY_DIR}/include)
+include_directories(${CLEAVER2_BINARY_DIR}/include)
 
 option(COPY_HEADER_FILES OFF)
 
@@ -90,10 +90,10 @@ if(COPY_HEADER_FILES) #TODO: Needs to be added to installation step for using as
     # When debugging, uncomment this line
     get_filename_component(file_no_path "${header_file}" NAME)
     configure_file("${header_file}"
-      "${CMAKE_BINARY_DIR}/include/cleaver/${file_no_path}" COPYONLY IMMEDIATE)
+      "${CLEAVER2_BINARY_DIR}/include/cleaver/${file_no_path}" COPYONLY IMMEDIATE)
     set(Cleaver_INSTALLED_HEADER_FILES
       ${Cleaver_INSTALLED_HEADER_FILES}
-      "${CMAKE_BINARY_DIR}/include/cleaver/${file_no_path}")
+      "${CLEAVER2_BINARY_DIR}/include/cleaver/${file_no_path}")
   endforeach()
 endif()
 

--- a/src/lib/jsoncpp/CMakeLists.txt
+++ b/src/lib/jsoncpp/CMakeLists.txt
@@ -17,10 +17,10 @@ set(JSONCPP_INSTALLED_HEADER_FILES)
 foreach(header_file ${JSONCPP_API_HEADER_FILES})
   get_filename_component(file_no_path "${header_file}" NAME)
   configure_file("${header_file}"
-    "${CMAKE_BINARY_DIR}/include/jsoncpp/${file_no_path}" COPYONLY IMMEDIATE)
+    "${CLEAVER2_BINARY_DIR}/include/jsoncpp/${file_no_path}" COPYONLY IMMEDIATE)
   set(JSONCPP_INSTALLED_HEADER_FILES
     ${JSONCPP_INSTALLED_HEADER_FILES}
-    "${CMAKE_BINARY_DIR}/include/jsoncpp/${file_no_path}")
+    "${CLEAVER2_BINARY_DIR}/include/jsoncpp/${file_no_path}")
 endforeach()
 
 # output library

--- a/src/lib/nrrd2cleaver/teem/CMakeLists.txt
+++ b/src/lib/nrrd2cleaver/teem/CMakeLists.txt
@@ -40,7 +40,7 @@ include_directories(${CLEAVER2_BINARY_DIR}/include)
 file(GLOB srcs *.cpp )
 file(GLOB hdrs *.h   )
 set(Nrrd2Cleaver_API_HEADER_FILES
-   ${CMAKE_SOURCE_DIR}/lib/nrrd2cleaver/NRRDTools.h)
+   ${CLEAVER2_SOURCE_DIR}/lib/nrrd2cleaver/NRRDTools.h)
 
 
 # copy header files over
@@ -50,10 +50,10 @@ foreach(header_file ${Nrrd2Cleaver_API_HEADER_FILES})
   #message(STATUS "Copy header file: ${header_file}")
   get_filename_component(file_no_path "${header_file}" NAME)
   configure_file("${header_file}"
-    "${CMAKE_BINARY_DIR}/include/nrrd2cleaver/${file_no_path}" COPYONLY IMMEDIATE)
+    "${CLEAVER2_BINARY_DIR}/include/nrrd2cleaver/${file_no_path}" COPYONLY IMMEDIATE)
   set(Nrrd2Cleaver_INSTALLED_HEADER_FILES
     ${Nrrd2Cleaver_INSTALLED_HEADER_FILES}
-    "${CMAKE_BINARY_DIR}/include/nrrd2cleaver/${file_no_path}")
+    "${CLEAVER2_BINARY_DIR}/include/nrrd2cleaver/${file_no_path}")
 endforeach()
 
 

--- a/src/lib/synthetic/CMakeLists.txt
+++ b/src/lib/synthetic/CMakeLists.txt
@@ -35,7 +35,7 @@ project(synthetic)
 cmake_minimum_required(VERSION 3.10.2)
 
 # Add library incl1udes
-include_directories(${CMAKE_BINARY_DIR}/include)
+include_directories(${CLEAVER2_BINARY_DIR}/include)
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ./)
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ../)
 
@@ -58,10 +58,10 @@ foreach(header_file ${Synthetic_API_HEADER_FILES})
   #message(STATUS "Copy header file: ${header_file}")
   get_filename_component(file_no_path "${header_file}" NAME)
   configure_file("${header_file}"
-    "${CMAKE_BINARY_DIR}/include/Synthetic/${file_no_path}" COPYONLY IMMEDIATE)
+    "${CLEAVER2_BINARY_DIR}/include/Synthetic/${file_no_path}" COPYONLY IMMEDIATE)
   set(Synthetic_INSTALLED_HEADER_FILES
     ${Synthetic_INSTALLED_HEADER_FILES}
-    "${CMAKE_BINARY_DIR}/include/Synthetic/${file_no_path}")
+    "${CLEAVER2_BINARY_DIR}/include/Synthetic/${file_no_path}")
 endforeach()
 
 # output library

--- a/src/lib/teem/CMake/CheckBigBitfield.cmake
+++ b/src/lib/teem/CMake/CheckBigBitfield.cmake
@@ -32,18 +32,18 @@ macro(CHECK_BIG_BITFIELD VARIABLE LOCAL_TEST_DIR)
  if("HAVE_${VARIABLE}" MATCHES "^HAVE_${VARIABLE}$")
   message(STATUS "Checking to see if this platform supports large bit-fields (>32 bits)")
   try_run(DUMMY ${VARIABLE}
-    ${CMAKE_BINARY_DIR}
+    ${CLEAVER2_BINARY_DIR}
     ${LOCAL_TEST_DIR}/CheckBigBitfield.c
     OUTPUT_VARIABLE OUTPUT)
   if(${VARIABLE})
     set(HAVE_${VARIABLE} TRUE CACHE INTERNAL " ")
     message(STATUS "Checking to see if this platform supports large bit-fields (>32 bits) - yes")
-    file(APPEND ${CMAKE_BINARY_DIR}/CMakeOutput.log
+    file(APPEND ${CLEAVER2_BINARY_DIR}/CMakeOutput.log
       "Checking to see if this platform supports large bit-fields (>32 bits) passed with "
       "the following output:\n${OUTPUT}\n\n")
   else()
     message(STATUS "Checking to see if this platform supports large bit-fields (>32 bits) - no")
-    file(APPEND ${CMAKE_BINARY_DIR}/CMakeError.log
+    file(APPEND ${CLEAVER2_BINARY_DIR}/CMakeError.log
       "Checking to see if this platform supports large bit-fields (>32 bits) failed with "
       "the following output:\n${OUTPUT}\n\n")
   endif()

--- a/src/lib/teem/CMake/TestNO_ICC_IDYNAMIC_NEEDED.cmake
+++ b/src/lib/teem/CMake/TestNO_ICC_IDYNAMIC_NEEDED.cmake
@@ -29,25 +29,25 @@
 macro(TESTNO_ICC_IDYNAMIC_NEEDED VARIABLE LOCAL_TEST_DIR)
   if("HAVE_${VARIABLE}" MATCHES "^HAVE_${VARIABLE}$")
     try_run(${VARIABLE} HAVE_${VARIABLE}
-      ${CMAKE_BINARY_DIR}
+      ${CLEAVER2_BINARY_DIR}
       ${LOCAL_TEST_DIR}/TestNO_ICC_IDYNAMIC_NEEDED.cxx
       OUTPUT_VARIABLE OUTPUT)
     message(STATUS "Check if using the Intel icc compiler, and if -i_dynamic is needed... COMPILE_RESULT...${HAVE_${VARIABLE}} RUN_RESULT...${VARIABLE}\n")
     if(HAVE_${VARIABLE}) #Test compiled, either working intel w/o -i_dynamic, or another compiler
       if(${VARIABLE})   #Intel icc compiler, -i_dynamic not needed
-        file(APPEND ${CMAKE_BINARY_DIR}/CMakeError.log
+        file(APPEND ${CLEAVER2_BINARY_DIR}/CMakeError.log
                        "-i_dynamic not needed, (Not Intel icc, or this version of Intel icc does not conflict with OS glibc.")
         message(STATUS "-i_dynamic not needed, (Not Intel icc, or this version of Intel icc does not conflict with OS glibc.")
       else() #The compiler is not Intel icc
-        file(APPEND ${CMAKE_BINARY_DIR}/CMakeError.log 
+        file(APPEND ${CLEAVER2_BINARY_DIR}/CMakeError.log 
                        "The compiler ERROR--This should never happen")
         message(STATUS "The compiler ERROR--This should never happen")
       endif()
     else()  #Test did not compile, either badly broken compiler, or intel -i_dynamic needed
-      file(APPEND ${CMAKE_BINARY_DIR}/CMakeError.log
+      file(APPEND ${CLEAVER2_BINARY_DIR}/CMakeError.log
             "\tThe -i_dynamic compiler flag is needed for the Intel icc compiler on this platform.\n")
       message("The -i_dynamic compiler flag is needed for the Intel icc compiler on this platform.")
     endif()
-    file(APPEND ${CMAKE_BINARY_DIR}/CMakeError.log "TestNO_ICC_IDYNAMIC_NEEDED produced following output:\n${OUTPUT}\n\n")
+    file(APPEND ${CLEAVER2_BINARY_DIR}/CMakeError.log "TestNO_ICC_IDYNAMIC_NEEDED produced following output:\n${OUTPUT}\n\n")
   endif()
 endmacro()

--- a/src/lib/teem/CMake/TestQnanhibit.cmake
+++ b/src/lib/teem/CMake/TestQnanhibit.cmake
@@ -31,7 +31,7 @@
 macro(TEST_QNANHIBIT VARIABLE LOCAL_TEST_DIR)
   if("HAVE_${VARIABLE}" MATCHES "^HAVE_${VARIABLE}$")
     try_run(${VARIABLE} HAVE_${VARIABLE}
-      ${CMAKE_BINARY_DIR}
+      ${CLEAVER2_BINARY_DIR}
       ${LOCAL_TEST_DIR}/TestQnanhibit.c
       OUTPUT_VARIABLE OUTPUT)
     message(STATUS "Check the value of the 22nd bit of a 32-bit quiet-NaN")
@@ -40,19 +40,19 @@ macro(TEST_QNANHIBIT VARIABLE LOCAL_TEST_DIR)
         message(ERROR " A test (qnanhibit.c) necessary for NrrdIO configuration returned error code. NrrdIO may not properly handle NaN's.")
       endif()
       if(${VARIABLE})
-        file(APPEND ${CMAKE_BINARY_DIR}/CMakeError.log
+        file(APPEND ${CLEAVER2_BINARY_DIR}/CMakeError.log
                     "Value of the 22nd bit of a 32-bit quiet-NaN is 1")
         message(STATUS "Check the value of the 22nd bit of a 32-bit quiet-NaN - 1")
       else()
-        file(APPEND ${CMAKE_BINARY_DIR}/CMakeError.log
+        file(APPEND ${CLEAVER2_BINARY_DIR}/CMakeError.log
                     "Value of the 22nd bit of a 32-bit quiet-NaN is 0")
         message(STATUS "Check the value of the 22nd bit of a 32-bit quiet-NaN - 0")
       endif()
     else()
-      file(APPEND ${CMAKE_BINARY_DIR}/CMakeError.log
+      file(APPEND ${CLEAVER2_BINARY_DIR}/CMakeError.log
         "\tFailed to compile a test (TestQnanhibit.c) necessary to configure for proper handling of IEEE floating point NaN's.\n")
       message(STATUS "Failed to compile a test (TestQnanhibit.c) necessary to configure for proper handling of IEEE floating point NaN's")
     endif()
-    file(APPEND ${CMAKE_BINARY_DIR}/CMakeError.log "TestQnanhibit.c produced following output:\n${OUTPUT}\n\n")
+    file(APPEND ${CLEAVER2_BINARY_DIR}/CMakeError.log "TestQnanhibit.c produced following output:\n${OUTPUT}\n\n")
   endif()
 endmacro()

--- a/src/lib/teem/CMakeLists.txt
+++ b/src/lib/teem/CMakeLists.txt
@@ -21,7 +21,7 @@
 #
 
 # This is the root Teem CMakeLists file
-cmake_minimum_required(VERSION 2.4)
+cmake_minimum_required(VERSION 3.10.2)
 
 
 # Remove PNG support, as teem uses deprecated libpng calls
@@ -60,8 +60,8 @@ include (CMakeBackwardCompatibilityC)
 
 #-----------------------------------------------------------------------------
 # Output directories.
-set (LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib CACHE INTERNAL "Single output directory for building all libraries.")
-set (EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin CACHE INTERNAL "Single output directory for building all executables.")
+# set (LIBRARY_OUTPUT_PATH ${CLEAVER2_BINARY_DIR}/lib CACHE INTERNAL "Single output directory for building all libraries.")
+# set (EXECUTABLE_OUTPUT_PATH ${CLEAVER2_BINARY_DIR}/bin CACHE INTERNAL "Single output directory for building all executables.")
 #output directory for installing all include files.")
 mark_as_advanced(LIBRARY_OUTPUT_PATH EXECUTABLE_OUTPUT_PATH)
 set(Teem_LIBRARY_PATH "${LIBRARY_OUTPUT_PATH}")
@@ -279,16 +279,16 @@ foreach(header_file ${Teem_HEADER_FILES})
   #message(STATUS "Copy header file: ${header_file}")
   get_filename_component(file_no_path "${header_file}" NAME)
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/${header_file}"
-    "${CMAKE_BINARY_DIR}/include/teem/${file_no_path}" COPYONLY IMMEDIATE)
+    "${CLEAVER2_BINARY_DIR}/include/teem/${file_no_path}" COPYONLY IMMEDIATE)
   set(Teem_INSTALLED_HEADER_FILES
     ${Teem_INSTALLED_HEADER_FILES}
-    "${CMAKE_BINARY_DIR}/include/teem/${file_no_path}")
+    "${CLEAVER2_BINARY_DIR}/include/teem/${file_no_path}")
 endforeach()
 
 #---
 # Include directory 
 include_directories(
-  "${CMAKE_BINARY_DIR}/include/"
+  "${CLEAVER2_BINARY_DIR}/include/"
   "${Teem_SOURCE_DIR}/include/"
   )
 

--- a/src/lib/teem/DartConfig.cmake
+++ b/src/lib/teem/DartConfig.cmake
@@ -20,7 +20,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #
 
-include(${CMAKE_SOURCE_DIR}/CTestConfig.cmake)
+include(${CLEAVER2_SOURCE_DIR}/CTestConfig.cmake)
 set(NIGHTLY_START_TIME "${CTEST_NIGHTLY_START_TIME}")
 set(DROP_METHOD "${CTEST_DROP_METHOD}")
 set(DROP_SITE "${CTEST_DROP_SITE}")

--- a/src/lib/teem/UseTeemCMakeDemo/CMakeLists.txt
+++ b/src/lib/teem/UseTeemCMakeDemo/CMakeLists.txt
@@ -1,6 +1,6 @@
 project (TeemSampleProject)
 
-cmake_minimum_required(VERSION 2.4)
+cmake_minimum_required(VERSION 3.10.2)
 
 if(COMMAND cmake_policy)
   cmake_policy(SET CMP0003 NEW)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,126 +1,23 @@
-# gtest external download
-set(EXTERNAL_DIR "${CMAKE_BINARY_DIR}/externals")
-set(GTEST_INSTALL_DIR "${EXTERNAL_DIR}/googletest")
-if(WIN32)
-  set(GTEST_SHARED_ARG ON)
-else()
-  set(GTEST_SHARED_ARG OFF)
-endif()
-
-include(ExternalProject)
-
-set(googletest_GIT_TAG "origin/cleaver")
-
-set(debug_suffix )
-if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-  set(debug_suffix d)
-endif()
-
-set(_ep_arg_build_byproducts)
-if("${CMAKE_GENERATOR}" STREQUAL "Ninja")
-  set(_build_byproducts "")
-  if(WIN32)
-    foreach(_lib IN ITEMS gtest gtest_main gmock gmock_main)
-      list(APPEND _build_byproducts
-        ${GTEST_INSTALL_DIR}/lib/lib/${CMAKE_FIND_LIBRARY_PREFIXES}${_lib}${debug_suffix}${CMAKE_STATIC_LIBRARY_SUFFIX})
-    endforeach()
-  else()
-    foreach(_lib IN ITEMS gtest gtest_main gmock gmock_main)
-      list(APPEND _build_byproducts ${GTEST_INSTALL_DIR}/lib/lib/${CMAKE_FIND_LIBRARY_PREFIXES}${_lib}${debug_suffix}${CMAKE_STATIC_LIBRARY_SUFFIX})
-    endforeach()
-  endif()
-  set(_ep_arg_build_byproducts BUILD_BYPRODUCTS ${_build_byproducts})
-endif()
-
-set(_cmake_cache_args)
-if(DEFINED CMAKE_BUILD_TYPE)
-  list(APPEND _cmake_cache_args -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE})
-endif()
-ExternalProject_Add(googletest
-   PREFIX "${GTEST_INSTALL_DIR}"
-   GIT_REPOSITORY "https://github.com/CIBC-Internal/googletest.git"
-   GIT_TAG ${googletest_GIT_TAG}
-   CMAKE_CACHE_ARGS
-     ${_cmake_cache_args}
-   INSTALL_DIR "${GTEST_INSTALL_DIR}/include"
-   BINARY_DIR "${GTEST_INSTALL_DIR}/lib"
-   INSTALL_COMMAND ""
-   ${_ep_arg_build_byproducts}
+# Fetch googletest via FetchContent (replaces CIBC-Internal/googletest ExternalProject)
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG v1.15.2
 )
-
-# Copy and Specify Include Directory
-ExternalProject_Get_Property(googletest source_dir)
-ExternalProject_Add_Step(
-   googletest
-   copy_deps
-   COMMAND ${CMAKE_COMMAND} -E copy_directory ${source_dir}/googletest/include ${GTEST_INSTALL_DIR}/include
-   COMMAND ${CMAKE_COMMAND} -E copy_directory ${source_dir}/googlemock/include ${GTEST_INSTALL_DIR}/include
-   DEPENDEES install
-)
-include_directories("${GTEST_INSTALL_DIR}/include")
-
-# Set up library paths
-set(GTEST_LIBRARY gtest)
-add_library(${GTEST_LIBRARY} UNKNOWN IMPORTED)
-ExternalProject_Get_Property(googletest binary_dir)
-if(NOT WIN32)
-  set(GTEST_LIBRARY_PATH_OTHER ${binary_dir}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}gtest${debug_suffix}${CMAKE_STATIC_LIBRARY_SUFFIX})
-  set_target_properties(${GTEST_LIBRARY} PROPERTIES IMPORTED_LOCATION ${GTEST_LIBRARY_PATH_OTHER})
-endif()
-add_dependencies(${GTEST_LIBRARY} googletest)
-
-set(GTEST_MAIN_LIBRARY gtest_main)
-add_library(${GTEST_MAIN_LIBRARY} UNKNOWN IMPORTED)
-if(NOT WIN32)
-  set(GTEST_MAIN_LIBRARY_PATH_OTHER ${binary_dir}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}gtest_main${debug_suffix}${CMAKE_STATIC_LIBRARY_SUFFIX})
-  set_target_properties(${GTEST_MAIN_LIBRARY} PROPERTIES IMPORTED_LOCATION ${GTEST_MAIN_LIBRARY_PATH_OTHER})
-endif()
-add_dependencies(${GTEST_MAIN_LIBRARY} googletest)
-
-set(GMOCK_LIBRARY gmock)
-add_library(${GMOCK_LIBRARY} UNKNOWN IMPORTED)
-if(NOT WIN32)
-  set(GMOCK_LIBRARY_PATH_OTHER ${binary_dir}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}gmock${debug_suffix}${CMAKE_STATIC_LIBRARY_SUFFIX})
-  set_target_properties(${GMOCK_LIBRARY} PROPERTIES IMPORTED_LOCATION ${GMOCK_LIBRARY_PATH_OTHER})
-endif()
-add_dependencies(${GMOCK_LIBRARY} googletest)
-
-set(GMOCK_MAIN_LIBRARY gmock_main)
-add_library(${GMOCK_MAIN_LIBRARY} UNKNOWN IMPORTED)
-if(NOT WIN32)
-  set(GMOCK_MAIN_LIBRARY_PATH_OTHER ${binary_dir}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}gmock_main${debug_suffix}${CMAKE_STATIC_LIBRARY_SUFFIX})
-  set_target_properties(${GMOCK_MAIN_LIBRARY} PROPERTIES IMPORTED_LOCATION ${GMOCK_MAIN_LIBRARY_PATH_OTHER})
-endif()
-add_dependencies(${GMOCK_MAIN_LIBRARY} ${GTEST_LIBRARY})
-
+# Prevent googletest from overriding our compiler/linker options
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
 
 # Definitions for Tests
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/test/bin)
-#test macro
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CLEAVER2_BINARY_DIR}/test/bin)
+
+# test macro
 function(NEWTEST name)
   add_executable(${name} ${name}.cpp ${ARGN})
-  if(NOT WIN32)
-    target_link_libraries(${name} ${GTEST_LIBRARY} ${GTEST_MAIN_LIBRARY} ${GMOCK_LIBRARY} ${GMOCK_MAIN_LIBRARY} cleaver -lpthread)
-  else ()
-    if (CMAKE_CONFIGURATION_TYPES)
-      target_link_libraries(${name}
-         ${binary_dir}/lib/$<CONFIG>/${CMAKE_FIND_LIBRARY_PREFIXES}gtest$<$<CONFIG:Debug>:d>${CMAKE_STATIC_LIBRARY_SUFFIX}
-         ${binary_dir}/lib/$<CONFIG>/${CMAKE_FIND_LIBRARY_PREFIXES}gtest_main$<$<CONFIG:Debug>:d>${CMAKE_STATIC_LIBRARY_SUFFIX}
-         ${binary_dir}/lib/$<CONFIG>/${CMAKE_FIND_LIBRARY_PREFIXES}gmock$<$<CONFIG:Debug>:d>${CMAKE_STATIC_LIBRARY_SUFFIX}
-         ${binary_dir}/lib/$<CONFIG>/${CMAKE_FIND_LIBRARY_PREFIXES}gmock_main$<$<CONFIG:Debug>:d>${CMAKE_STATIC_LIBRARY_SUFFIX}
-          cleaver )
-    else()
-      # Ninja
-      target_link_libraries(${name}
-       ${binary_dir}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}gtest$<$<CONFIG:Debug>:d>${CMAKE_STATIC_LIBRARY_SUFFIX}
-       ${binary_dir}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}gtest_main$<$<CONFIG:Debug>:d>${CMAKE_STATIC_LIBRARY_SUFFIX}
-       ${binary_dir}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}gmock$<$<CONFIG:Debug>:d>${CMAKE_STATIC_LIBRARY_SUFFIX}
-       ${binary_dir}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}gmock_main$<$<CONFIG:Debug>:d>${CMAKE_STATIC_LIBRARY_SUFFIX}
-          cleaver )
-    endif()
-  endif()
-  add_test(${name} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${name})
-  add_dependencies(${name} gtest gtest_main cleaver)
+  target_link_libraries(${name} GTest::gtest_main GTest::gmock cleaver)
+  add_test(NAME ${name} COMMAND ${name})
 endfunction()
 
 add_subdirectory(cleaver)


### PR DESCRIPTION
Fix CMake >= 4.0 compatibility and improve add_subdirectory integration. Supersedes #129 (includes all its changes with cleaned-up commit history).

Motivated by SCIInstitute/ITKCleaver#77 — the ITK remote module CI currently works around these issues by forcing `BUILD_TESTING OFF` for the vendored Cleaver lib.

<details>
<summary>Commits (3)</summary>

1. **COMP: Scope CMake variables for add_subdirectory integration** — replace CMAKE_BINARY_DIR/CMAKE_SOURCE_DIR with CLEAVER2_BINARY_DIR/CLEAVER2_SOURCE_DIR throughout; unset EXECUTABLE_OUTPUT_PATH to prevent propagation to consuming projects (from #129, squashed and attributed)
2. **COMP: Replace CIBC-Internal/googletest with google/googletest v1.15.2** — FetchContent with modern CMake targets replaces 120-line ExternalProject + manual library path handling
3. **COMP: Bump vendored teem cmake_minimum_required to 3.10.2** — old VERSION 2.4 rejected by CMake >= 4.0; upstream teem now requires 3.25

</details>

<!--
provenance: claude-code session 2026-04-15
supersedes: #129
downstream: SCIInstitute/ITKCleaver#77
-->